### PR TITLE
sistemato il problema della GUI

### DIFF
--- a/debianize.sh
+++ b/debianize.sh
@@ -40,9 +40,9 @@ if [[ "$ACTION" == "C" || "$ACTION" == "c" || "$ACTION" == "" ]]; then
 	#elif [ -f /etc/redhat-release ]; then
 		# Older Red Hat, CentOS, etc.
 	else
-	    # Fall back to uname, e.g. "Linux <version>", also works for BSD, etc.
-	    OS=$(uname -s)
-	    DEBIANVER=$(uname -r)
+		# Fall back to uname, e.g. "Linux <version>", also works for BSD, etc.
+		OS=$(uname -s)
+		DEBIANVER=$(uname -r)
 	fi
 	###echo OS:$OS DEBIANVER:$DEBIANVER
 
@@ -70,15 +70,17 @@ elif [[ "$ACTION" == "D" || "$ACTION" == "d" ]]; then
 	echo "So, please copy the already compiled: airspaceconverter libairspaceconverter.so and airspaceconverter-gui binaries to this folder."
 	read -p "Press ENTER when done"
 
+	if [ "$1" != "test" ]; then
 	# Instead of building just copy the binaries (make sure they are executable as well)
-	chmod a+x airspaceconverter
-	chmod a+x airspaceconverter-gui
-	mkdir -p Release
-	mv airspaceconverter ./Release/airspaceconverter
-	mv libairspaceconverter.so ./Release/libairspaceconverter.so
-	mkdir -p buildQt
-	mv airspaceconverter-gui ./buildQt/airspaceconverter-gui
-	
+		chmod a+x airspaceconverter
+		chmod a+x airspaceconverter-gui
+		mkdir -p Release
+		mv airspaceconverter ./Release/airspaceconverter
+		mv libairspaceconverter.so ./Release/libairspaceconverter.so
+		mkdir -p buildQt
+		mv airspaceconverter-gui ./buildQt/airspaceconverter-gui
+	fi
+
 	# Ask the user for which version of Debian we are building the packages	
 	printf "Enter target Debian release number [7-9,16.04]: "
 	read -r DEBIANVER
@@ -400,11 +402,15 @@ rm -f airspaceconverter-gui_${VERSION}-${DEBIANVER}_${ARCH}.deb
 dpkg-deb --build airspaceconverter-gui_${VERSION}-${DEBIANVER}_${ARCH}
 
 # Clean
-rm -R buildQt
+if [ "$1" != "test" ]; then
+	rm -R buildQt
+fi
 sudo rm -R airspaceconverter_${VERSION}-${DEBIANVER}_${ARCH}
 sudo rm -R airspaceconverter-gui_${VERSION}-${DEBIANVER}_${ARCH}
 if [[ "$ACTION" == "D" || "$ACTION" == "d" ]]; then
-	echo cleaning
-	make clean
+	if [ "$1" != "test" ]; then
+		echo cleaning
+		make clean
+	fi
 fi
 exit 0

--- a/src/AirspaceConverter.cpp
+++ b/src/AirspaceConverter.cpp
@@ -199,7 +199,7 @@ void AirspaceConverter::LoadAirspaces(const OutputType suggestedTypeForOutputFil
 		}
 	}
 	airspaceFiles.clear();
-	if (counter > 0) LogMessage(boost::str(boost::format("Red successfully %1d airspace definition(s) from %2d file(s).") %(airspaces.size() - airspaceCounter) %counter), false);
+	if (counter > 0) LogMessage(boost::str(boost::format("Read successfully %1d airspace definition(s) from %2d file(s).") %(airspaces.size() - airspaceCounter) %counter), false);
 }
 
 void AirspaceConverter::UnloadAirspaces() {
@@ -212,7 +212,7 @@ void AirspaceConverter::LoadTerrainRasterMaps() {
 	int counter = 0;
 	for (const std::string& demFile : terrainRasterMapFiles) if (KML::AddTerrainMap(demFile)) counter++;
 	terrainRasterMapFiles.clear();
-	if (counter > 0) LogMessage(boost::str(boost::format("Red successfully %1d terrain raster map file(s).") % counter), false);
+	if (counter > 0) LogMessage(boost::str(boost::format("Read successfully %1d terrain raster map file(s).") % counter), false);
 }
 
 void AirspaceConverter::UnloadRasterMaps() {
@@ -230,7 +230,7 @@ void AirspaceConverter::LoadWaypoints() {
 		if (redOk && outputFile.empty()) outputFile = boost::filesystem::path(inputFile).replace_extension(".kmz").string(); // Default output as KMZ
 	}
 	waypointFiles.clear();
-	if (counter > 0) LogMessage(boost::str(boost::format("Red successfully %1d waypoint(s) from %2d file(s).") % (waypoints.size() - wptCounter) %counter), false);
+	if (counter > 0) LogMessage(boost::str(boost::format("Read successfully %1d waypoint(s) from %2d file(s).") % (waypoints.size() - wptCounter) %counter), false);
 }
 
 void AirspaceConverter::UnloadWaypoints() {

--- a/src/OpenAIP.cpp
+++ b/src/OpenAIP.cpp
@@ -9,7 +9,6 @@
 //
 // This source file is part of AirspaceConverter project
 //============================================================================
-
 #include "OpenAIP.h"
 #include "Airspace.h"
 #include "AirspaceConverter.h"
@@ -70,6 +69,8 @@ bool ReadAltitude(const ptree& node, Altitude& altitude) {
 	return false;
 }
 
+#include <boost/format.hpp>
+
 bool OpenAIP::Read(const std::string& fileName, std::multimap<int, Airspace>& output) {
 	std::ifstream input(fileName);
 	if (!input.is_open() || input.bad()) {
@@ -81,6 +82,7 @@ bool OpenAIP::Read(const std::string& fileName, std::multimap<int, Airspace>& ou
 	read_xml(input, tree);
 	input.close();
 	ptree root;
+	setlocale(LC_ALL, "C"); // so std::stod recognize dot as decimal sep
 	try {
 		root = tree.get_child("OPENAIP");
 		double value = root.get_child("<xmlattr>").get<double>("DATAFORMAT");


### PR DESCRIPTION
1) Fixed conversion error AIP->AIR using the GUI, related to locale settings
File:OpenAIP.cpp   Function:OpenAIP::Read
added setlocale(LC_ALL, "C"); so std::stod recognize dot as decimal separator
2) test parameter for debianize.sh
3) Typo Red -> Read in AirspaceConverter.cpp

NB. non so se la chiamata alla 'setlocale' vada li o se è meglio da un'altra parte all'inizio dell'esecuzione una volta per tutte, ma li sicuramente funziona.
Nel sorgente è rimasto un #include <boost/format.hpp> che avevo messo per debug