### PR TITLE
#179: Use fixed, not scientific, format for output in Polish

### DIFF
--- a/src/Polish.cpp
+++ b/src/Polish.cpp
@@ -143,10 +143,10 @@ bool Polish::Write(const std::string& filename, const std::multimap<int, Airspac
 		double lat,lon;
 		for (size_t i=0; i<a.GetNumberOfPoints()-1; i++) {
 			a.GetPointAt(i).GetLatLon(lat,lon);
-			file << "(" << lat << "," << lon << "),";
+			file << std::fixed << "(" << lat << "," << lon << "),";
 		}
 		a.GetLastPoint().GetLatLon(lat,lon);
-		file << "(" << lat << "," << lon << ")\n";
+		file << std::fixed << "(" << lat << "," << lon << ")\n";
 
 		//file<< "EndLevel=4\n";
 


### PR DESCRIPTION
When converting for Garmin so using cGPSmapper: the problem is that a longitude very close to the Greenwich meridian (so to 0) results as very small number in exponential format which is not recognized by cGPSmapper.