### PR TITLE
added Debian 13 as supported target

### DIFF
--- a/debianize.sh
+++ b/debianize.sh
@@ -173,6 +173,17 @@ case $OSVER in
 		QTDEPS="libqt5core5a (>= ${QTVER}), libqt5gui5 (>= ${QTVER}), libqt5widgets5 (>= ${QTVER}), libgl1-mesa-glx (>= 18.3.6)"
 		MANT="Valerio Messina <efa@iol.it>"
 		;;
+	13)
+		echo "Packaging for Debian 13 Trixie..."
+		DISTR=deb
+		LIBCVER=2.41
+		ZIPLIB=libzip4
+		ZIPVER=1.7.3
+		BOOSTVER=1.83.0
+		QTVER=5.15.15
+		QTDEPS="libqt5core5a (>= ${QTVER}), libqt5gui5 (>= ${QTVER}), libqt5widgets5 (>= ${QTVER}), libgl1-mesa-glx (>= 18.3.6)"
+		MANT="Valerio Messina <efa@iol.it>"
+		;;
 	4)
 		echo "Packaging for LMDE4 (Debian 10 Buster)..."
 		DISTR=lmde


### PR DESCRIPTION
Some notes

1) libraries in Debian 13 seems changed names:
```
libgl1-mesa-glx                       22.3.6-1+deb12u1
libqt5core5a  (results in catalog, but not installable) 5.15.8+dfsg-11+deb12u3

old name_______     new name_________ version
libqt5core5a    ==> libqt5core5t64    5.15.15+dfsg-6  (qtbase-opensource-src)
libqt5gui5      ==> libqt5gui5t64     5.15.15+dfsg-6
libqt5widgets5  ==> libqt5widgets5t64 5.15.15+dfsg-6
```
the libraries package has a new trail in name from 'a' to 't64'.
Anyway debianize.sh create the two .deb packages, and I can install them without issues on deps.

2) On Debian 13 I got this WARN in package creation:

```
dpkg-deb: attenzione: root directory airspaceconverter_0.4.3-deb13_amd64 has unusual owner or group 1000:1000
dpkg-deb: hint: you might need to pass --root-owner-group, see <https://wiki.debian.org/Teams/Dpkg/RootlessBuilds> for further details

dpkg-deb: attenzione: root directory airspaceconverter-gui_0.4.3-deb13_amd64 has unusual owner or group 1000:1000
dpkg-deb: hint: you might need to pass --root-owner-group, see <https://wiki.debian.org/Teams/Dpkg/RootlessBuilds> for further details
```

I will dig how to solve it in a next PR