### PR TITLE
#200: Start to adopt Naviter specs for OpenAir

### DIFF
--- a/QtGUI/AirspaceConverterQt.pro
+++ b/QtGUI/AirspaceConverterQt.pro
@@ -17,9 +17,8 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
 TARGET = airspaceconverter-gui
 TEMPLATE = app
-
-greaterThan(QT_MAJOR_VERSION, 4): CONFIG += c++23
-lessThan(QT_MAJOR_VERSION, 5): QMAKE_CXXFLAGS += -std=c++23
+CONFIG += c++23
+QMAKE_CXXFLAGS += -std=c++23
 
 RESOURCES += \
     resources.qrc

--- a/QtGUI/MainWindow.cpp
+++ b/QtGUI/MainWindow.cpp
@@ -31,7 +31,7 @@
 #include <QFutureWatcher>
 #include <filesystem>
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/format.hpp>
+#include <format>
 #include <cassert>
 #include "AirspaceConverter.hpp"
 #include "Altitude.hpp"
@@ -187,7 +187,7 @@ void MainWindow::refreshUI() {
 void MainWindow::endBusy() {
     if (busy) { // Stop the timer
         const double elapsedTimeSec = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - startTime).count() / 1e6;
-        logMessage(QString::fromStdString(std::string(boost::str(boost::format("Execution time: %1f sec.") %elapsedTimeSec))));
+        logMessage(QString::fromStdString(std::format("Execution time: {} sec.", elapsedTimeSec)));
     }
 
     // Set the numer of airspaces loaded in its spinBox

--- a/QtGUI/MainWindow.cpp
+++ b/QtGUI/MainWindow.cpp
@@ -218,7 +218,7 @@ void MainWindow::on_outputFormatComboBox_currentIndexChanged(int index) {
 }
 
 void MainWindow::on_loadAirspaceFileButton_clicked() {
-    QStringList filenames = QFileDialog::getOpenFileNames(this, tr("Airspace files"), suggestedInputDir, tr("All airspace files(*.txt *.TXT *.aip *.AIP *.kml *.KML *.kmz *.KMZ);;OpenAir(*.txt *.TXT);;openAIP(*.aip *.AIP);;Google Earth(*.kml *.KML *.kmz *.KMZ);;") );
+    QStringList filenames = QFileDialog::getOpenFileNames(this, tr("Airspace files"), suggestedInputDir, tr("All airspace files(*.openair *.OPENAIR *.OpenAir *.txt *.TXT *.aip *.AIP *.kml *.KML *.kmz *.KMZ);;OpenAir(*.openair *.OPENAIR *.OpenAir *.txt *.TXT);;openAIP(*.aip *.AIP);;Google Earth(*.kml *.KML *.kmz *.KMZ);;") );
     if(filenames.empty()) return;
 
     // Start to work
@@ -252,7 +252,7 @@ void MainWindow::on_loadAirspaceFolderButton_clicked() {
     for (std::filesystem::directory_iterator it(std::filesystem::path(selectedDir.toStdString())), endit; it != endit; ++it) {
         if (std::filesystem::is_regular_file(*it)) {
             const std::string ext = it->path().extension().string();
-            if (boost::iequals(ext, ".txt") || boost::iequals(ext, ".aip") || boost::iequals(ext, ".kmz") || boost::iequals(ext, ".kml"))
+            if (boost::iequals(ext, ".openair") || boost::iequals(ext, ".txt") || boost::iequals(ext, ".aip") || boost::iequals(ext, ".kmz") || boost::iequals(ext, ".kml"))
                 converter->AddAirspaceFile(it->path().string());
         }
     }
@@ -353,7 +353,7 @@ void MainWindow::on_convertButton_clicked() {
     // The desired format is initially dictated by the combo box: the user will have it already preselected in the file dialog
     switch(ui->outputFormatComboBox->currentIndex()) {
         case AirspaceConverter::OutputType::KMZ_Format:     selectedFilter = tr("Google Earth(*.kmz)"); break;
-        case AirspaceConverter::OutputType::OpenAir_Format: selectedFilter = tr("OpenAir(*.txt)"); break;
+        case AirspaceConverter::OutputType::OpenAir_Format: selectedFilter = tr("OpenAir(*.openair)"); break;
         case AirspaceConverter::OutputType::SeeYou_Format:  selectedFilter = tr("SeeYou(*.cup)"); break;
         case AirspaceConverter::OutputType::CSV_Format:     selectedFilter = tr("LittleNavMap(*.csv)"); break;
         case AirspaceConverter::OutputType::Polish_Format:  selectedFilter = tr("Polish(*.mp)"); break;
@@ -365,8 +365,8 @@ void MainWindow::on_convertButton_clicked() {
     std::string desiredOutputFile = QFileDialog::getSaveFileName(this, tr("Convert to..."),
                                                                  QString::fromStdString(std::filesystem::path(converter->GetOutputFile()).replace_extension("").string()),
                                                                  AirspaceConverter::Is_cGPSmapperAvailable() ?
-                                                                     tr("Google Earth(*.kmz);;OpenAir(*.txt);;SeeYou(*.cup);;LittleNavMap(*.csv);;Polish(*.mp);;Garmin img(*.img)") :
-                                                                     tr("Google Earth(*.kmz);;OpenAir(*.txt);;SeeYou(*.cup);;LittleNavMap(*.csv);;Polish(*.mp)"),
+                                                                     tr("Google Earth(*.kmz);;OpenAir(*.openair);;SeeYou(*.cup);;LittleNavMap(*.csv);;Polish(*.mp);;Garmin img(*.img)") :
+                                                                     tr("Google Earth(*.kmz);;OpenAir(*.openair);;SeeYou(*.cup);;LittleNavMap(*.csv);;Polish(*.mp)"),
                                                                  &selectedFilter).toStdString();
 
     // If no file selected or entered: do nothing
@@ -381,7 +381,7 @@ void MainWindow::on_convertButton_clicked() {
         // In this case, may be, the user typed just a name but selecting the extension in the save as combo box file type
         desiredFormat = AirspaceConverter::KMZ_Format; // KMZ default
         if (selectedFilter != "Google Earth(*.kmz)") {
-            if (selectedFilter == "OpenAir(*.txt)") desiredFormat = AirspaceConverter::OpenAir_Format;
+            if (selectedFilter == "OpenAir(*.openair)") desiredFormat = AirspaceConverter::OpenAir_Format;
             else if (selectedFilter == "SeeYou(*.cup)") desiredFormat = AirspaceConverter::SeeYou_Format;
             else if (selectedFilter == "LittleNavMap(*.csv)") desiredFormat = AirspaceConverter::CSV_Format;
             else if (selectedFilter == "Polish(*.mp)") desiredFormat = AirspaceConverter::Polish_Format;

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Can write in the following formats:
 
 While converting to _OpenAir_ AirspaceConverter estimates if the points are part of arcs or circumferences in order to make use of arc and circumference definitions of the _OpenAir_ format and so avoiding to output all points one by one.  
 The ability to read **KML**/**KMZ** is based on the **KMZ** airspace files produced by _Austrocontrol_. This utility can convert also _SeeYou_ **.CUP** waypoint files to **KMZ** (for _Google Earth_). The conversion to **IMG** for _Garmin_ devices is done using _cGPSmapper_.  
-AirspaceConverter is written in C++17 and runs on _Linux_, _Windows_ and _macOS_. In order to be immediately easy to use it has _Qt_ and _Windows MFC_ user interfaces. But it can also work from command line.  
+AirspaceConverter is written in C++20 and runs on _Linux_, _Windows_ and _macOS_. In order to be immediately easy to use it has _Qt_ and _Windows MFC_ user interfaces. But it can also work from command line.  
 
 
 For more information's about this project: [alus.it/AirspaceConverter](https://www.alus.it/AirspaceConverter)  

--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ The `airspaceconverter` command line executable, works taking several arguments,
 Possible options:  
   - **-q**: optional, specify the QNH in hPa used to calculate height of flight levels  
   - **-a**: optional, specify a default terrain altitude in meters to calculate AGL heights of points not covered by loaded terrain map(s)  
-  - **-i**: multiple, input file(s) can be _OpenAir_ (**.txt**), _openAIP_ (**.aip**), _Google Earth_ **.kmz**, **.kml**)  
+  - **-i**: multiple, input file(s) can be _OpenAir_ (**.openair**, **.txt**), _openAIP_ (**.aip**), _Google Earth_ **.kmz**, **.kml**)  
   - **-w**: multiple, input waypoint file(s) can be _SeeYou_ (**.cup**), _openAIP_ (**.aip**) or _LittleNavMap_ (**.csv**)  
   - **-m**: optional, multiple, terrain map file(s) (**.dem**) used to lookup terrain heights  
   - **-l**: optional, set filter limits in latitude and longitude for the output, followed by the 4 limit values: northLat,southLat,westLon,eastLon where the limits are comma separated, expressed in degrees, without spaces, negative for west longitudes and south latitudes  
   - **-u**: optional, set filter limits in altitude for the output, followed by 1 or 2 limit values: lowAltitude,hiAltitude where the limits are comma separated, expressed in feet, without spaces. If the high limit is omitted it will be considered as unlimited.  
-  - **-o**: optional, output file **.kmz** (_Google Earth_), **.txt** (_OpenAir_), **.cup** (_SeeYou_), **.csv** (_LittleNavMap_), **.img** (_Garmin_) or **.mp** (_Polish_). If not specified will be used the name of first input file as **KMZ**  
+  - **-o**: optional, output file **.kmz** (_Google Earth_), **.openair**, **.txt** (_OpenAir_), **.cup** (_SeeYou_), **.csv** (_LittleNavMap_), **.img** (_Garmin_) or **.mp** (_Polish_). If not specified will be used the name of first input file as **KMZ**  
   - **-p**: optional, when writing in _OpenAir_ avoid to use arcs and circles but only points (DP)  
   - **-s**: optional, when writing in _OpenAir_ use coordinates always with minutes and seconds (DD:MM:SS)  
   - **-d**: optional, when writing in _OpenAir_ use coordinates always with decimal minutes (DD:MM.MMM)  
@@ -92,7 +92,7 @@ This is the default way to use the graphical user interface:
 1. Choose the desired output format.
 2. If needed, specify the QNH to be used for calculating the height of flight levels, this must be done before reading airspace files.
 3. If converting to _GoogleEarth_ specify a default terrain altitude to be used for the points not under terrain raster map coverage.
-4. Select as input multiple _openAIP_ (**.aip**) _OpenAir_ (**.txt**) and/or _GoogleEarth_ (**.kmz**) files or the folder containing them.
+4. Select as input multiple _openAIP_ (**.aip**) _OpenAir_ (**.openair**, **.txt**) and/or _GoogleEarth_ (**.kmz**) files or the folder containing them.
 5. If converting to _GoogleEarth_ or to find missing altitudes of _SeeYou_ waypoints it is possible to load multiple raster map files (**.dem**) with the terrain altitude.
 6. And/or select one or multiple waypoints files (**.cup**, **.csv**) or the folder containing them.
 7. Optionally configure the latitude and longitude ranges for filtering the output.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ On older _Ubuntu_ or _Debian_ install `libqt4-dev` instead of `libqt5-private-de
 On _Fedora_:  
 `sudo dnf install libzip-devel boost-devel qt-devel lsb-release`  
 Then, to compile, from the root of this project: `./build.sh`  
-To install: `./install.sh`  
+To install: `sudo ./install.sh`  
 This will install everything: the shared library the command line executable and the _Qt_ GUI interface.  
 After it will be possible to run AirspaceConverter CLI from anywhere simply calling: `airspaceconverter`  
 The same for the AirspaceConverter _Qt_ GUI graphical interface: `airspaceconverter-gui`  

--- a/Windows/AirspaceConverter/AirspaceConverter.vcxproj
+++ b/Windows/AirspaceConverter/AirspaceConverter.vcxproj
@@ -70,7 +70,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CONSOLE;_WIN32_WINNT=0x0601;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -87,7 +87,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CONSOLE;_WIN32_WINNT=0x0601;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/Windows/AirspaceConverterLib/AirspaceConverterLib.vcxproj
+++ b/Windows/AirspaceConverterLib/AirspaceConverterLib.vcxproj
@@ -70,7 +70,7 @@
       <SDLCheck>true</SDLCheck>
       <TreatWarningAsError>false</TreatWarningAsError>
       <MultiProcessorCompilation>false</MultiProcessorCompilation>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -89,7 +89,7 @@
       <SDLCheck>true</SDLCheck>
       <TreatWarningAsError>false</TreatWarningAsError>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Windows/AirspaceConverterMFC/AirspaceConverterDlg.cpp
+++ b/Windows/AirspaceConverterMFC/AirspaceConverterDlg.cpp
@@ -18,8 +18,7 @@
 #include "LimitsDlg.hpp"
 #include "Processor.hpp"
 #include "AirspaceConverter.hpp"
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/format.hpp>
 #include <boost/locale/encoding.hpp>
@@ -392,7 +391,7 @@ void CAirspaceConverterDlg::EndBusy(const bool takeTime /* = false */) {
 	if (processor != nullptr) processor->Join();
 	if (takeTime) {
 		const double elapsedTimeSec = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - startTime).count() / 1e6;
-		LogMessage(std::string(boost::str(boost::format("Execution time: %1f sec.") % elapsedTimeSec)));
+		LogMessage(std::string(std::format("Execution time: %1f sec.") % elapsedTimeSec)));
 	}
 	if(converter != nullptr) {
 		numAirspacesLoaded = converter->GetNumOfAirspaces();
@@ -444,7 +443,7 @@ void CAirspaceConverterDlg::OnBnClickedInputFile() {
 		POSITION pos(dlg.GetStartPosition());
 		while (pos) {
 			const std::string inputFilename(CT2CA(dlg.GetNextPathName(pos)));
-			if (!boost::filesystem::is_regular_file(inputFilename)) continue;
+			if (!std::filesystem::is_regular_file(inputFilename)) continue;
 			converter->AddAirspaceFile(inputFilename);
 			if(outputFile.empty()) outputFile = inputFilename;
 		}
@@ -463,7 +462,7 @@ void CAirspaceConverterDlg::OnBnClickedInputWaypoints() {
 		POSITION pos(dlg.GetStartPosition());
 		while (pos) {
 			const std::string inputFilename(CT2CA(dlg.GetNextPathName(pos)));
-			if (!boost::filesystem::is_regular_file(inputFilename)) continue;
+			if (!std::filesystem::is_regular_file(inputFilename)) continue;
 			if(outputFile.empty()) outputFile = inputFilename;
 			converter->AddWaypointFile(inputFilename);
 		}
@@ -482,7 +481,7 @@ void CAirspaceConverterDlg::OnBnClickedLoadDEM() {
 		POSITION pos(dlg.GetStartPosition());
 		while (pos) {
 			const std::string inputFilename(CT2CA(dlg.GetNextPathName(pos)));
-			if (!boost::filesystem::is_regular_file(inputFilename)) continue;
+			if (!std::filesystem::is_regular_file(inputFilename)) continue;
 			converter->AddTerrainRasterMapFile(inputFilename);
 		}
 		if (processor != nullptr && processor->LoadDEMfiles()) StartBusy();
@@ -506,10 +505,10 @@ void CAirspaceConverterDlg::OnBnClickedInputFolderBt() {
 
 	outputFile.clear();
 	conversionDone = false;
-	boost::filesystem::path root(inputPath);
-	if (!boost::filesystem::exists(root) || !boost::filesystem::is_directory(root)) return; //this should never happen
-	for (boost::filesystem::directory_iterator it(root), endit; it != endit; ++it) {
-		if (boost::filesystem::is_regular_file(*it)) {
+	std::filesystem::path root(inputPath);
+	if (!std::filesystem::exists(root) || !std::filesystem::is_directory(root)) return; //this should never happen
+	for (std::filesystem::directory_iterator it(root), endit; it != endit; ++it) {
+		if (std::filesystem::is_regular_file(*it)) {
 			const std::string ext = it->path().extension().string();
 			if (boost::iequals(ext, ".openair") || boost::iequals(ext, ".txt") || boost::iequals(ext, ".aip") || boost::iequals(ext, ".kmz") || boost::iequals(ext, ".kml")) {
 				converter->AddAirspaceFile(it->path().string());
@@ -534,10 +533,10 @@ void CAirspaceConverterDlg::OnBnClickedInputWaypointsFolderBt() {
 	else return;
 	assert(!inputPath.empty());
 
-	boost::filesystem::path root(inputPath);
-	if (!boost::filesystem::exists(root) || !boost::filesystem::is_directory(root)) return; //this should never happen
-	for (boost::filesystem::directory_iterator it(root), endit; it != endit; ++it) {
-		if (boost::filesystem::is_regular_file(*it)) {
+	std::filesystem::path root(inputPath);
+	if (!std::filesystem::exists(root) || !std::filesystem::is_directory(root)) return; //this should never happen
+	for (std::filesystem::directory_iterator it(root), endit; it != endit; ++it) {
+		if (std::filesystem::is_regular_file(*it)) {
 			const std::string ext = it->path().extension().string();
 			if (boost::iequals(ext, ".cup") || boost::iequals(ext, ".aip") || boost::iequals(ext, ".csv")) {
 				converter->AddWaypointFile(it->path().string());
@@ -562,10 +561,10 @@ void CAirspaceConverterDlg::OnBnClickedLoadDemFolderBt() {
 	else return;
 	assert(!inputPath.empty());
 
-	boost::filesystem::path root(inputPath);
-	if (!boost::filesystem::exists(root) || !boost::filesystem::is_directory(root)) return; //this should never happen
-	for (boost::filesystem::directory_iterator it(root), endit; it != endit; ++it) {
-		if (boost::filesystem::is_regular_file(*it) && boost::iequals(it->path().extension().string(), ".dem"))
+	std::filesystem::path root(inputPath);
+	if (!std::filesystem::exists(root) || !std::filesystem::is_directory(root)) return; //this should never happen
+	for (std::filesystem::directory_iterator it(root), endit; it != endit; ++it) {
+		if (std::filesystem::is_regular_file(*it) && boost::iequals(it->path().extension().string(), ".dem"))
 			converter->AddTerrainRasterMapFile(it->path().string());
 	}
 	if (processor != nullptr && processor->LoadDEMfiles()) StartBusy();
@@ -635,7 +634,7 @@ void CAirspaceConverterDlg::OnBnClickedConvert() {
 	assert(!outputFile.empty());
 	
 	// Prepare and show the open file dialog asking where the user wants to save the converted file
-	boost::filesystem::path outputPath(outputFile);
+	std::filesystem::path outputPath(outputFile);
 	CFileDialog dlg(FALSE, NULL, CString(outputPath.stem().c_str()) , OFN_HIDEREADONLY, AirspaceConverter::Is_cGPSmapperAvailable() ?
 			_T("KMZ|*.kmz|OpenAir|*.openair|SeeYou|*.cup|LittleNavMap|*.csv|Polish|*.mp|Garmin|*.img||") :
 			_T("KMZ|*.kmz|OpenAir|*.openair|SeeYou|*.cup|LittleNavMap|*.csv|Polish|*.mp||"),
@@ -661,7 +660,7 @@ void CAirspaceConverterDlg::OnBnClickedConvert() {
 	if (outputFile.empty()) return;
 	AirspaceConverter::OutputType type = (AirspaceConverter::OutputType)OutputTypeCombo.GetCurSel();
 	assert(type >= AirspaceConverter::OutputType::KMZ_Format && type < AirspaceConverter::OutputType::Unknown_Format);
-	if (boost::filesystem::exists(outputPath)) { // check if file already exists
+	if (std::filesystem::exists(outputPath)) { // check if file already exists
 		CString msg(outputFile.c_str());
 		msg += "\nalready exists, overwrite?";
 		if (MessageBox(msg, _T("Overwrite?"), MB_YESNO | MB_ICONINFORMATION) == IDYES) std::remove(outputFile.c_str());
@@ -673,8 +672,8 @@ void CAirspaceConverterDlg::OnBnClickedConvert() {
 	switch (type) {
 	case AirspaceConverter::OutputType::KMZ_Format:
 		{
-			boost::filesystem::path kmlPath(outputPath.parent_path() / boost::filesystem::path("doc.kml"));
-			if (boost::filesystem::exists(kmlPath)) {
+			std::filesystem::path kmlPath(outputPath.parent_path() / std::filesystem::path("doc.kml"));
+			if (std::filesystem::exists(kmlPath)) {
 				if (MessageBox(_T("In the output folder the file doc.kml already exists.\nIn order to make the KMZ it will be overwritten and deleted. Continue?"), _T("Overwrite?"), MB_YESNO | MB_ICONINFORMATION) == IDYES) std::remove(kmlPath.string().c_str());
 				else return;
 			}
@@ -706,9 +705,9 @@ void CAirspaceConverterDlg::OnBnClickedConvert() {
 		break;
 	case AirspaceConverter::OutputType::Garmin_Format:
 		{
-			boost::filesystem::path polishPath(outputPath);
+			std::filesystem::path polishPath(outputPath);
 			polishPath.replace_extension(".mp");
-			if (boost::filesystem::exists(polishPath)) {
+			if (std::filesystem::exists(polishPath)) {
 				CString msg(polishPath.c_str());
 				msg += " already exists.\nIn order to make the IMG it will be overwritten and deleted. Continue?";
 					if (MessageBox(msg, _T("Overwrite?"), MB_YESNO | MB_ICONINFORMATION) == IDYES) std::remove(polishPath.string().c_str());

--- a/Windows/AirspaceConverterMFC/AirspaceConverterDlg.cpp
+++ b/Windows/AirspaceConverterMFC/AirspaceConverterDlg.cpp
@@ -19,8 +19,8 @@
 #include "Processor.hpp"
 #include "AirspaceConverter.hpp"
 #include <filesystem>
+#include <format>
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/format.hpp>
 #include <boost/locale/encoding.hpp>
 
 #ifdef _DEBUG

--- a/Windows/AirspaceConverterMFC/AirspaceConverterDlg.cpp
+++ b/Windows/AirspaceConverterMFC/AirspaceConverterDlg.cpp
@@ -436,7 +436,7 @@ void CAirspaceConverterDlg::OnBnClickedInputFile() {
 	assert(converter != nullptr);
 	assert(processor != nullptr);
 	if (!UpdateData(TRUE)) return; // Force the user to enter valid QNH
-	CFileDialog dlg(TRUE, NULL, NULL, OFN_ALLOWMULTISELECT | OFN_FILEMUSTEXIST, _T("All airspace files|*.txt; *.aip; *.kmz; *.kml|openAIP airspace|*.aip|OpenAir|*.txt|Google Earth|*.kmz; *.kml||"), (CWnd*)this, 0, TRUE);
+	CFileDialog dlg(TRUE, NULL, NULL, OFN_ALLOWMULTISELECT | OFN_FILEMUSTEXIST, _T("All airspace files|*.openair; *.txt; *.aip; *.kmz; *.kml|OpenAir|.openair; *.txt|openAIP airspace|*.aip|Google Earth|*.kmz; *.kml||"), (CWnd*)this, 0, TRUE);
 	dlg.GetOFN().lpstrTitle = L"Load airspace file(s)";
 	if (dlg.DoModal() == IDOK) {
 		outputFile.clear();
@@ -511,7 +511,7 @@ void CAirspaceConverterDlg::OnBnClickedInputFolderBt() {
 	for (boost::filesystem::directory_iterator it(root), endit; it != endit; ++it) {
 		if (boost::filesystem::is_regular_file(*it)) {
 			const std::string ext = it->path().extension().string();
-			if (boost::iequals(ext, ".txt") || boost::iequals(ext, ".aip") || boost::iequals(ext, ".kmz") || boost::iequals(ext, ".kml")) {
+			if (boost::iequals(ext, ".openair") || boost::iequals(ext, ".txt") || boost::iequals(ext, ".aip") || boost::iequals(ext, ".kmz") || boost::iequals(ext, ".kml")) {
 				converter->AddAirspaceFile(it->path().string());
 				if (outputFile.empty()) outputFile = it->path().string();
 			}
@@ -637,8 +637,8 @@ void CAirspaceConverterDlg::OnBnClickedConvert() {
 	// Prepare and show the open file dialog asking where the user wants to save the converted file
 	boost::filesystem::path outputPath(outputFile);
 	CFileDialog dlg(FALSE, NULL, CString(outputPath.stem().c_str()) , OFN_HIDEREADONLY, AirspaceConverter::Is_cGPSmapperAvailable() ?
-			_T("KMZ|*.kmz|OpenAir|*.txt|SeeYou|*.cup|LittleNavMap|*.csv|Polish|*.mp|Garmin|*.img||") :
-			_T("KMZ|*.kmz|OpenAir|*.txt|SeeYou|*.cup|LittleNavMap|*.csv|Polish|*.mp||"),
+			_T("KMZ|*.kmz|OpenAir|*.openair|SeeYou|*.cup|LittleNavMap|*.csv|Polish|*.mp|Garmin|*.img||") :
+			_T("KMZ|*.kmz|OpenAir|*.openair|SeeYou|*.cup|LittleNavMap|*.csv|Polish|*.mp||"),
 		(CWnd*)this, 0, TRUE);
 	dlg.GetOFN().lpstrTitle = L"Convert to ...";
 	dlg.GetOFN().lpstrInitialDir = CString(outputPath.parent_path().c_str());

--- a/Windows/AirspaceConverterMFC/AirspaceConverterDlg.cpp
+++ b/Windows/AirspaceConverterMFC/AirspaceConverterDlg.cpp
@@ -391,7 +391,7 @@ void CAirspaceConverterDlg::EndBusy(const bool takeTime /* = false */) {
 	if (processor != nullptr) processor->Join();
 	if (takeTime) {
 		const double elapsedTimeSec = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - startTime).count() / 1e6;
-		LogMessage(std::string(std::format("Execution time: %1f sec.") % elapsedTimeSec)));
+		LogMessage(std::format("Execution time: {} sec.", elapsedTimeSec));
 	}
 	if(converter != nullptr) {
 		numAirspacesLoaded = converter->GetNumOfAirspaces();

--- a/Windows/AirspaceConverterMFC/AirspaceConverterMFC.vcxproj
+++ b/Windows/AirspaceConverterMFC/AirspaceConverterMFC.vcxproj
@@ -71,7 +71,7 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <MultiProcessorCompilation>false</MultiProcessorCompilation>
       <AdditionalIncludeDirectories>..\..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -99,7 +99,7 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AdditionalIncludeDirectories>..\..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Windows/AirspaceConverterMFC/Processor.cpp
+++ b/Windows/AirspaceConverterMFC/Processor.cpp
@@ -13,9 +13,8 @@
 #include "stdafx.h"
 #include "Processor.hpp"
 #include "AirspaceConverter.hpp"
-#include <boost/filesystem/path.hpp>
+#include <format>
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/format.hpp>
 
 Processor::Processor(HWND hwnd, AirspaceConverter* airspaceConverter) :
 	window(hwnd) ,
@@ -33,7 +32,7 @@ bool Processor::cGPSmapper(const std::string& polishFile, const std::string& out
 	AirspaceConverter::LogMessage("Invoking cGPSmapper to make: " + outputFile);
 
 	//TODO: add arguments to create files also for other software like Garmin BaseCamp
-	const std::string args(boost::str(boost::format("%1s -o %2s") % polishFile %outputFile));
+	const std::string args(std::format("{} -o {}", polishFile, outputFile));
 
 	SHELLEXECUTEINFO lpShellExecInfo = { 0 };
 	lpShellExecInfo.cbSize = sizeof(SHELLEXECUTEINFO);

--- a/airspaceconverter.1
+++ b/airspaceconverter.1
@@ -73,7 +73,7 @@ Specify a default terrain altitude in meters to calculate AGL heights of points 
 Default is 20 m.
 .TP
 .BR \-i " " \fIinputFile\fR
-Multiple, input airspace file(s) can be OpenAir (.txt), openAIP (.aip), Google Earth (.kmz, .kml).
+Multiple, input airspace file(s) can be OpenAir (.openair, .txt), openAIP (.aip), Google Earth (.kmz, .kml).
 At least one input airspace or waypoint file must be present.
 Additional input airspace files must be specified repeating the option \-i in front of each of them.
 OpenAir input files are expected to be encoded in ANSI but if encoded in UTF-8 with BOM they will be also read properly.
@@ -101,7 +101,7 @@ The limits are comma separated, expressed in feet, without spaces.
 If the high limit is omitted it will be considered as unlimited.
 .TP
 .BR \-o " " \fIoutputFile\fR
-Output file, can be: .kmz (Google Earth), .txt (OpenAir), .cup (SeeYou), .csv (LittleNavMap), .img (Garmin) or .mp (Polish).
+Output file, can be: .kmz (Google Earth), .opeair, .txt (OpenAir), .cup (SeeYou), .csv (LittleNavMap), .img (Garmin) or .mp (Polish).
 If not specified will be used the name of first input file as KMZ.
 Output OpenAir files will be always encoded in ANSI.
 WARNING: any already existing output file will be automatically overwritten.

--- a/src/AirspaceConverter.cpp
+++ b/src/AirspaceConverter.cpp
@@ -192,7 +192,8 @@ bool AirspaceConverter::PutTypeExtension(const OutputType type, std::string& fil
 		outputPath.replace_extension(".kmz");
 		break;
 	case OutputType::OpenAir_Format:
-		outputPath.replace_extension(".openair");
+		if (boost::iequals(outputPath.extension().string(), ".txt")) outputPath.replace_extension(".txt"); // If file requested with .txt leave it with .txt
+		else outputPath.replace_extension(".openair"); // othrwise use the default .openair extension
 		break;
 	case OutputType::SeeYou_Format:
 		outputPath.replace_extension(".cup");

--- a/src/AirspaceConverter.cpp
+++ b/src/AirspaceConverter.cpp
@@ -499,25 +499,44 @@ bool AirspaceConverter::ParseAltitude(const std::string& text, const bool isTop,
 	return true;
 }
 
-std::string AirspaceConverter::GetCreationDateString() {
+std::string AirspaceConverter::GetCurrentDateString() {
+	const time_t now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+	std::stringstream ss;
+#ifdef __GNUC__
+#if __GNUC__ > 4
+	ss << std::put_time(gmtime(&now), "%d-%m-%Y");
+#else
+	char dateString[20];
+	struct tm *utc;
+	utc = gmtime(&now);
+	strftime(dateString, sizeof(dateString), "%d-%m-%Y", utc);
+	ss << dateString;
+#endif
+#elif _WIN32
+	struct tm utc;
+	gmtime_s(&utc, &now);
+	ss << std::put_time(&utc, "%d-%m-%Y");
+#endif
+	return ss.str();
+}
+
+std::string AirspaceConverter::GetFullCreationDateTimeString() {
 	const time_t now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 	std::stringstream ss;
 #ifdef __GNUC__
 #if __GNUC__ > 4
 	ss << "This file was created on: " << std::put_time(gmtime(&now), "%a %d %B %Y at %T UTC");
 #else
-	char dateString[40];
+	char dateTimeString[40];
 	struct tm *utc;
 	utc = gmtime(&now);
-	strftime(dateString, sizeof(dateString), "%a %d %B %Y at %T UTC", utc);
-	ss << "This file was created on: " << dateString;
+	strftime(dateTimeString, sizeof(dateTimeString), "%a %d %B %Y at %T UTC", utc);
+	ss << "This file was created on: " << dateTimeString;
 #endif
-#else
-#ifdef _WIN32
+#elif _WIN32
 	struct tm utc;
 	gmtime_s(&utc, &now);
 	ss << "This file was created on: " << std::put_time(&utc, "%a %d %B %Y at %T UTC");
-#endif
 #endif
 	return ss.str();
 }

--- a/src/AirspaceConverter.cpp
+++ b/src/AirspaceConverter.cpp
@@ -29,8 +29,8 @@
 #include <map>
 #include <tuple>
 #include <filesystem>
-#include <boost/algorithm/string/predicate.hpp>
 #include <format>
+#include <boost/algorithm/string/predicate.hpp>
 
 // The HTTP client used to check for new version from Boost Beast is available from version 1.70
 #if BOOST_VERSION >= 107000

--- a/src/AirspaceConverter.cpp
+++ b/src/AirspaceConverter.cpp
@@ -31,13 +31,9 @@
 #include <filesystem>
 #include <format>
 #include <boost/algorithm/string/predicate.hpp>
-
-// The HTTP client used to check for new version from Boost Beast is available from version 1.70
-#if BOOST_VERSION >= 107000
-#include <boost/beast/core.hpp>
+#include <boost/beast/core.hpp> // The HTTP client used to check for new version from Boost Beast is available from version 1.70
 #include <boost/beast/http.hpp>
 #include <boost/beast/version.hpp>
-#endif
 
 #ifdef __linux__ // If on Linux...
 	const std::string AirspaceConverter::basePath(std::filesystem::canonical("/proc/self/exe").parent_path().string());
@@ -505,15 +501,7 @@ std::string AirspaceConverter::GetCurrentDateString() {
 	const time_t now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 	std::stringstream ss;
 #ifdef __GNUC__
-#if __GNUC__ > 4
 	ss << std::put_time(gmtime(&now), "%d-%m-%Y");
-#else
-	char dateString[20];
-	struct tm *utc;
-	utc = gmtime(&now);
-	strftime(dateString, sizeof(dateString), "%d-%m-%Y", utc);
-	ss << dateString;
-#endif
 #elif _WIN32
 	struct tm utc;
 	gmtime_s(&utc, &now);
@@ -526,15 +514,7 @@ std::string AirspaceConverter::GetFullCreationDateTimeString() {
 	const time_t now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 	std::stringstream ss;
 #ifdef __GNUC__
-#if __GNUC__ > 4
 	ss << "This file was created on: " << std::put_time(gmtime(&now), "%a %d %B %Y at %T UTC");
-#else
-	char dateTimeString[40];
-	struct tm *utc;
-	utc = gmtime(&now);
-	strftime(dateTimeString, sizeof(dateTimeString), "%a %d %B %Y at %T UTC", utc);
-	ss << "This file was created on: " << dateTimeString;
-#endif
 #elif _WIN32
 	struct tm utc;
 	gmtime_s(&utc, &now);
@@ -702,7 +682,6 @@ int AirspaceConverter::VersionToNumber(const std::string& versionString) {
 }
 
 bool AirspaceConverter::CheckForNewVersion(int& versionDifference) {
-	#if BOOST_VERSION >= 107000
 	static const int runningVersionNumber = VersionToNumber(VERSION);
 	assert(runningVersionNumber > 0 && runningVersionNumber < 1000);
 	try {
@@ -758,6 +737,5 @@ bool AirspaceConverter::CheckForNewVersion(int& versionDifference) {
 	} catch (...) {
 		// This can happen in many cases including when no Internet connection is available; so: no need to bother the user
 	}
-	#endif
 	return false;
 }

--- a/src/AirspaceConverter.cpp
+++ b/src/AirspaceConverter.cpp
@@ -169,16 +169,17 @@ std::istream& AirspaceConverter::SafeGetline(std::istream& is, std::string& line
 }
 
 AirspaceConverter::OutputType AirspaceConverter::DetermineType(const std::string& filename) {
-	if (filename.empty()) return OutputType::KMZ_Format; // KMZ default
 	OutputType outputType = OutputType::KMZ_Format; // KMZ default
-	std::string outputExt(std::filesystem::path(filename).extension().string());
-	if (!boost::iequals(outputExt, ".kmz")) {
-		if (boost::iequals(outputExt, ".txt")) outputType = OutputType::OpenAir_Format;
-		else if (boost::iequals(outputExt, ".cup")) outputType = OutputType::SeeYou_Format;
-		else if (boost::iequals(outputExt, ".mp")) outputType = OutputType::Polish_Format;
-		else if (boost::iequals(outputExt, ".img")) outputType = OutputType::Garmin_Format;
-		else if (boost::iequals(outputExt, ".csv")) outputType = OutputType::CSV_Format;
-		else outputType = OutputType::Unknown_Format;
+	if (!filename.empty()) {
+		const std::string outputExt(std::filesystem::path(filename).extension().string());
+		if (!boost::iequals(outputExt, ".kmz")) {
+			if (boost::iequals(outputExt, ".openair") || boost::iequals(outputExt, ".txt")) outputType = OutputType::OpenAir_Format;
+			else if (boost::iequals(outputExt, ".cup")) outputType = OutputType::SeeYou_Format;
+			else if (boost::iequals(outputExt, ".mp")) outputType = OutputType::Polish_Format;
+			else if (boost::iequals(outputExt, ".img")) outputType = OutputType::Garmin_Format;
+			else if (boost::iequals(outputExt, ".csv")) outputType = OutputType::CSV_Format;
+			else outputType = OutputType::Unknown_Format;
+		}
 	}
 	return outputType;
 }
@@ -191,7 +192,7 @@ bool AirspaceConverter::PutTypeExtension(const OutputType type, std::string& fil
 		outputPath.replace_extension(".kmz");
 		break;
 	case OutputType::OpenAir_Format:
-		outputPath.replace_extension(".txt");
+		outputPath.replace_extension(".openair");
 		break;
 	case OutputType::SeeYou_Format:
 		outputPath.replace_extension(".cup");
@@ -225,7 +226,7 @@ void AirspaceConverter::LoadAirspaces(const OutputType suggestedTypeForOutputFil
 	const size_t initialAirspacesNumber = airspaces.size(); // Airspaces originally already loaded
 	for (const std::string& inputFile : airspaceFiles) {
 		const std::string ext(std::filesystem::path(inputFile).extension().string());
-		if(boost::iequals(ext, ".txt")) openAir.Read(inputFile);
+		if(boost::iequals(ext, ".openair") || boost::iequals(ext, ".txt")) openAir.Read(inputFile);
 		else if (boost::iequals(ext, ".aip")) openAIP.ReadAirspaces(inputFile);
 		else if (boost::iequals(ext, ".kmz")) kml.ReadKMZ(inputFile);
 		else if (boost::iequals(ext, ".kml")) kml.ReadKML(inputFile);
@@ -243,7 +244,7 @@ void AirspaceConverter::LoadAirspaces(const OutputType suggestedTypeForOutputFil
 				outputFile = std::filesystem::path(inputFile).replace_extension(".kmz").string();
 				break;
 			case OutputType::OpenAir_Format:
-				outputFile = std::filesystem::path(inputFile).replace_extension(".txt").string();
+				outputFile = std::filesystem::path(inputFile).replace_extension(".openair").string();
 				break;
 			case OutputType::Polish_Format:
 				outputFile = std::filesystem::path(inputFile).replace_extension(".mp").string();

--- a/src/AirspaceConverter.cpp
+++ b/src/AirspaceConverter.cpp
@@ -30,7 +30,7 @@
 #include <tuple>
 #include <filesystem>
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/format.hpp>
+#include <format>
 
 // The HTTP client used to check for new version from Boost Beast is available from version 1.70
 #if BOOST_VERSION >= 107000
@@ -126,7 +126,7 @@ bool AirspaceConverter::Default_cGPSmapper(const std::string& polishFile, const 
 	LogMessage("Invoking cGPSmapper to make: " + outputFile);
 
 	//TODO: add arguments to create files also for other software like Garmin BaseCamp
-	const std::string cmd(boost::str(boost::format("%1s \"%2s\" -o \"%3s\"") %cGPSmapperCommand %polishFile %outputFile));
+	const std::string cmd(std::format("{} \"{}\" -o \"{}\"", cGPSmapperCommand, polishFile, outputFile));
 	LogMessage("Executing: " + cmd);
 	if(system(cmd.c_str()) == EXIT_SUCCESS) {
 		std::remove(polishFile.c_str()); // Delete polish file
@@ -254,7 +254,7 @@ void AirspaceConverter::LoadAirspaces(const OutputType suggestedTypeForOutputFil
 				outputFile = std::filesystem::path(inputFile).replace_extension(".img").string();
 		}
 	}
-	LogMessage(boost::str(boost::format("Read %1d airspace definition(s) from %2d file(s).") %(airspaces.size() - initialAirspacesNumber) %airspaceFiles.size()));
+	LogMessage(std::format("Read {} airspace definition(s) from {} file(s).", airspaces.size() - initialAirspacesNumber, airspaceFiles.size()));
 	airspaceFiles.clear();
 }
 
@@ -270,7 +270,7 @@ void AirspaceConverter::LoadTerrainRasterMaps() {
 	int counter = 0;
 	for (const std::string& demFile : terrainRasterMapFiles) if (AddTerrainMap(demFile)) counter++;
 	terrainRasterMapFiles.clear();
-	if (counter > 0) LogMessage(boost::str(boost::format("Read successfully %1d terrain raster map file(s).") % counter));
+	if (counter > 0) LogMessage(std::format("Read successfully {} terrain raster map file(s).", counter));
 }
 
 void AirspaceConverter::UnloadRasterMaps() {
@@ -300,7 +300,7 @@ void AirspaceConverter::LoadWaypoints() {
 		if (readOk && outputFile.empty()) outputFile = std::filesystem::path(inputFile).replace_extension(".kmz").string(); // Default output as KMZ
 	}
 	waypointFiles.clear();
-	if (counter > 0) LogMessage(boost::str(boost::format("Read successfully %1d waypoint(s) from %2d file(s).") % (waypoints.size() - wptCounter) %counter));
+	if (counter > 0) LogMessage(std::format("Read successfully {} waypoint(s) from {} file(s).", waypoints.size() - wptCounter, counter));
 }
 
 void AirspaceConverter::UnloadWaypoints() {
@@ -599,7 +599,7 @@ bool AirspaceConverter::FilterOnLatLonLimits(const double& topLat, const double&
 			if ((*it).second.IsWithinLatLonLimits(limits)) ++it;
 			else it = airspaces.erase(it);
 		}
-		LogMessage(boost::str(boost::format("Filtering airspaces on position... excluded: %1d, remaining: %2d") %(origAirspaces - GetNumOfAirspaces()) %GetNumOfAirspaces()));
+		LogMessage(std::format("Filtering airspaces on position... excluded: {}, remaining: {}", origAirspaces - GetNumOfAirspaces(), GetNumOfAirspaces()));
 	}
 
 	// Filter waypoints
@@ -613,7 +613,7 @@ bool AirspaceConverter::FilterOnLatLonLimits(const double& topLat, const double&
 				delete(w);
 			}
 		}
-		LogMessage(boost::str(boost::format("Filtering waypoints on position... excluded: %1d, remaining: %2d ") %(origWaypoints - GetNumOfWaypoints()) %GetNumOfWaypoints()));
+		LogMessage(std::format("Filtering waypoints on position... excluded: {}, remaining: {}", origWaypoints - GetNumOfWaypoints(), GetNumOfWaypoints()));
 	}
 	return true;
 }
@@ -632,7 +632,7 @@ bool AirspaceConverter::FilterOnAltitudeLimits(const Altitude& floor, const Alti
 			if ((*it).second.IsWithinAltLimits(floor, ceiling)) ++it;
 			else it = airspaces.erase(it);
 		}
-		LogMessage(boost::str(boost::format("Filtering airspaces on altitude... excluded: %1d, remaining: %2d") %(origAirspaces - GetNumOfAirspaces()) %GetNumOfAirspaces()));
+		LogMessage(std::format("Filtering airspaces on altitude... excluded: {}, remaining: {}", origAirspaces - GetNumOfAirspaces(), GetNumOfAirspaces()));
 	}
 
 	// Filter waypoints
@@ -648,7 +648,7 @@ bool AirspaceConverter::FilterOnAltitudeLimits(const Altitude& floor, const Alti
 				delete(w);
 			}
 		}
-		LogMessage(boost::str(boost::format("Filtering waypoints on altitude... excluded: %1d, remaining: %2d ") %(origWaypoints - GetNumOfWaypoints()) %GetNumOfWaypoints()));
+		LogMessage(std::format("Filtering waypoints on altitude... excluded: {}, remaining: {}", origWaypoints - GetNumOfWaypoints(), GetNumOfWaypoints()));
 	}
 	return true;
 }
@@ -675,18 +675,18 @@ bool AirspaceConverter::VerifyAltitudeOnTerrainMap(const double& lat, const doub
 		if (altitudeParsed) {
 			const double delta = isSpike ? alt - terrainAlt : fabs(alt - terrainAlt); // Spike such as an antenna, tower, VOR, etc: consider higher theresold in this case
 			if (isSpike ? delta > 100 || delta < 0 : terrainAlt > 5 ? delta > 10 : delta > 15) { // Consider bigger threshold if delta > 5 m (maybe it was really intended AMSL)
-				LogWarning(boost::str(boost::format("on line %1d: detected altitude difference of: %2g m respect ground, using terrain altitude: %3g m") %line %delta %terrainAlt));
+				LogWarning(std::format("on line {}: detected altitude difference of: {} m respect ground, using terrain altitude: {} m", line, delta, terrainAlt));
 				alt = (float)terrainAlt;
 			}
 		} else {
-			if (blankAltitude) LogWarning(boost::str(boost::format("on line %1d: blank elevation, using terrain altitude: %2g m") %line %terrainAlt));
-			else LogWarning(boost::str(boost::format("on line %1d: invalid elevation, using terrain altitude: %2g m") %line %terrainAlt));
+			if (blankAltitude) LogWarning(std::format("on line {}: blank elevation, using terrain altitude: {} m", line, terrainAlt));
+			else LogWarning(std::format("on line {}: invalid elevation, using terrain altitude: {} m", line,terrainAlt));
 			alt = (float)terrainAlt;
 		}
 		return true;
 	} 
-	if (blankAltitude) LogWarning(boost::str(boost::format("on line %1d: blank elevation, waypoint out of loaded terrain maps: assuming AMSL") %line));
-	else if (!altitudeParsed) LogWarning(boost::str(boost::format("on line %1d: invalid elevation, waypoint out of loaded terrain maps: assuming AMSL") %line));
+	if (blankAltitude) LogWarning(std::format("on line {}: blank elevation, waypoint out of loaded terrain maps: assuming AMSL", line));
+	else if (!altitudeParsed) LogWarning(std::format("on line {}: invalid elevation, waypoint out of loaded terrain maps: assuming AMSL", line));
 	return false;
 }
 

--- a/src/AirspaceConverter.hpp
+++ b/src/AirspaceConverter.hpp
@@ -59,7 +59,8 @@ public:
 	static bool PutTypeExtension(const OutputType type, std::string& filename);
 	static bool ParseAltitude(const std::string& text, const bool isTop, Airspace& airspace);
 	inline static bool isDigit(const char c) { return (c >= '0' && c <= '9'); }
-	static std::string GetCreationDateString();
+	static std::string GetCurrentDateString();
+	static std::string GetFullCreationDateTimeString();
 	static bool CheckAirbandFrequency(const double& frequencyMHz, int& frequencyHz);
 	static bool CheckVORfrequency(const double& frequencyMHz, int& frequencyHz);
 	static bool CheckNDBfrequency(const double& frequencykHz, int& frequencyHz);

--- a/src/KML.cpp
+++ b/src/KML.cpp
@@ -301,7 +301,7 @@ void KML::OpenPlacemark(const Airspace& airspace) {
 		<< "<SimpleData name=\"Perimeter\">" << perimeter << "</SimpleData>\n"
 		<< "</SchemaData>\n"
 		<< "</ExtendedData>\n";
-	outputFile.unsetf(std::ios_base::floatfield); //outputFile << std::defaultfloat; not supported by older GCC 4.9.0
+	outputFile << std::defaultfloat;
 }
 
 void KML::OpenPlacemark(const Waypoint* waypoint) {
@@ -334,7 +334,7 @@ void KML::OpenPlacemark(const Waypoint* waypoint) {
 		else if (waypoint->GetType() == Waypoint::WaypointType::NDB)
 			outputFile << "<SimpleData name=\"NDB\">" << std::setprecision(1) << AirspaceConverter::FrequencykHz(waypoint->GetOtherFrequency()) << "</SimpleData>\n";
 	}
-	outputFile.unsetf(std::ios_base::floatfield); //outputFile << std::defaultfloat; not supported by older GCC 4.9.0
+	outputFile << std::defaultfloat;
 	outputFile << "<SimpleData name=\"Desc\">" << PrepareTagText(waypoint->GetDescription()) << "</SimpleData>\n"
 		<< "</SchemaData>\n"
 		<< "</ExtendedData>\n";

--- a/src/KML.cpp
+++ b/src/KML.cpp
@@ -681,27 +681,15 @@ bool KML::Write(const std::string& filename) {
 	zip_source* source = zip_source_file(archive, fileKML.c_str(), 0, 0);
 	if (source == nullptr) { // "failed to create source buffer. " << zip_strerror(archive)
 		// Discard zip file. In case ZIP_FL_OVERWRITE is not defined we are using an older libzib version such as 0.10.1, so we have to use the older functions
-#ifdef ZIP_FL_OVERWRITE
 		zip_discard(archive);
-#else
-		zip_close(archive);
-#endif
 		AirspaceConverter::LogError("Failed to create zip source buffer to read: " + fileKML);
 		return false;
 	}
 
 	// Add the buffer as KLM file in the ZIP
-#ifdef ZIP_FL_OVERWRITE
 	int index = (int)zip_file_add(archive, "doc.kml", source, ZIP_FL_OVERWRITE);
-#else
-	int index = (int)zip_add(archive, "doc.kml", source);
-#endif
 	if (index < 0) { // "failed to add file to archive. " << zip_strerror(archive)
-#ifdef ZIP_FL_OVERWRITE
 		zip_discard(archive);
-#else
-		zip_close(archive);
-#endif
 		zip_source_free(source); // The sorce buffer have to be freed in this case
 		AirspaceConverter::LogError("While compressing, failed to add: doc.kml");
 		return false;
@@ -722,28 +710,16 @@ bool KML::Write(const std::string& filename) {
 			// Create source buffer from KML file
 			source = zip_source_file(archive, iconPath.c_str(), 0, 0);
 			if (source == nullptr) { // "failed to create source buffer. " << zip_strerror(archive)
-#ifdef ZIP_FL_OVERWRITE
 				zip_discard(archive);
-#else
-				zip_close(archive);
-#endif
 				AirspaceConverter::LogError("Failed to create zip source buffer to read: " + iconPath);
 				return false;
 			}
 
 			// Add the buffer as PNG file in the ZIP
 			const std::string iconFile = "icons/" + waypointIcons[i];
-#ifdef ZIP_FL_OVERWRITE
 			index = (int)zip_file_add(archive, iconFile.c_str(), source, ZIP_FL_OVERWRITE);
-#else
-			index = (int)zip_add(archive, iconFile.c_str(), source);
-#endif
 			if (index < 0) { // "failed to add file to archive. " << zip_strerror(archive)
-#ifdef ZIP_FL_OVERWRITE
 				zip_discard(archive);
-#else
-				zip_close(archive);
-#endif
 				zip_source_free(source); // The sorce buffer have to be freed in this case
 				AirspaceConverter::LogError("While compressing, failed to add: " + iconFile);
 				return false;

--- a/src/KML.cpp
+++ b/src/KML.cpp
@@ -18,11 +18,11 @@
 #include "Geometry.hpp"
 #include <zip.h>
 #include <filesystem>
+#include <cmath>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/tokenizer.hpp>
-#include <cmath>
 
 const std::string KML::colors[Airspace::Type::UNDEFINED] = {
 	"9900ff", //CLASSA

--- a/src/KML.cpp
+++ b/src/KML.cpp
@@ -167,7 +167,7 @@ void KML::WriteHeader(const bool airspacePresent, const bool waypointsPresent) {
 	outputFile << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
 		<< "<!--\n";
 	for(const std::string& line: AirspaceConverter::disclaimer) outputFile << line << "\n";
-	outputFile << "\n" << AirspaceConverter::GetCreationDateString() << " -->\n"
+	outputFile << "\n" << AirspaceConverter::GetFullCreationDateTimeString() << " -->\n"
 		<< "<kml xmlns = \"http://www.opengis.net/kml/2.2\">\n"
 		<< "<Document>\n"
 		<< "<open>true</open>\n";

--- a/src/OpenAIP.cpp
+++ b/src/OpenAIP.cpp
@@ -17,10 +17,10 @@
 #include "Airfield.hpp"
 #include <cmath>
 #include <fstream>
+#include <format>
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/tokenizer.hpp>
-#include <boost/format.hpp>
 
 using boost::property_tree::ptree;
 
@@ -300,7 +300,7 @@ bool OpenAIP::ParseAirports(const ptree& airportsNode) {
 		AirspaceConverter::LogError("Expected to find at least one AIRPORT tag inside WAYPOINTS tag.");
 		return false;
 	}
-	AirspaceConverter::LogMessage(boost::str(boost::format("This openAIP waypoint file contains %1d airfields") %numOfAirports));
+	AirspaceConverter::LogMessage(std::format("This openAIP waypoint file contains {} airfields", numOfAirports));
 
 	for (ptree::value_type const& ap : airportsNode) { // for all children of WAYPOINTS tag
 		try {
@@ -454,7 +454,7 @@ bool OpenAIP::ParseNavAids(const ptree& navAidsNode) {
 		AirspaceConverter::LogError("Expected to find at least one NAVAID tag inside NAVAIDS tag.");
 		return false;
 	}
-	AirspaceConverter::LogMessage(boost::str(boost::format("This openAIP navaids file contains %1d navigation aids") %numOfNavAids));
+	AirspaceConverter::LogMessage(std::format("This openAIP navaids file contains {} navigation aids.", numOfNavAids));
 
 	for (ptree::value_type const& na : navAidsNode) { // for all children of WAYPOINTS tag
 		try {

--- a/src/OpenAir.cpp
+++ b/src/OpenAir.cpp
@@ -336,8 +336,7 @@ bool OpenAir::Read(const std::string& fileName) {
 				lineParsedOK = ParseDC(sLine, airspace);
 				break;
 			case 'Y': // DY
-				//ParseDY(sLine, airspace); // Airway not yet supported
-				AirspaceConverter::LogWarning(std::format("skipping airway segment (not yet supported) on line {}: {}", linecount, sLine));
+				AirspaceConverter::LogWarning(std::format("skipping airway segment (deprecated) on line {}: {}", linecount, sLine));
 				lineParsedOK = false; 
 				break;
 			default:
@@ -456,14 +455,14 @@ bool OpenAir::ParseDP(const std::string& line, Airspace& airspace, const int& li
 				// If this point is matching the first point (can happen that last point matches the first point of last geometry) ... 
 				size_t numGeo = airspace.GetNumberOfGeometries();
 				if (numGeo > 1 && !airspace.GetGeometryAt(numGeo - 1)->IsPoint() && airspace.GetFirstPoint() == point) {
-					
-					// ... take a note that the last point is matching the fisrt (as it should be)
+
+					// ... take a note that the last point is matching the first (as it should be)
 					lastPointWasEqualToFirst = true;
 					return true;
 				}
 			}
 
-			// If the last point equal to the first was alredy detected than there is really a duplicate
+			// If the last point equal to the first was already detected than there is really a duplicate
 			AirspaceConverter::LogWarning(std::format("skipping unnecessary repeated point on line {}: {}", linenumber, line));	
 		}
 		return true;
@@ -553,20 +552,6 @@ bool OpenAir::ParseDC(const std::string& line, Airspace& airspace) {
 	}
 	return true;
 }
-
-/* Airway not yet supported
-bool OpenAir::ParseDY(const std::string & line, Airspace& airspace)
-{
-	if (airspace.GetType() == Airspace::UNDEFINED) return true;
-	if (varWidth == 0 || line.length() < 14) return false;
-	double lat = 0, lon = 0;
-	if (ParseCoordinates(line.substr(3), lat, lon)) {
-		airspace.AddGeometry(new AirwayPoint(lat, lon, varWidth));
-		return true;
-	} 
-	return false;
-}
-*/
 
 bool OpenAir::InsertAirspace(Airspace& airspace) {
 	if (airspace.GetType() == Airspace::UNDEFINED || airspace.GetName().empty()) {

--- a/src/OpenAir.cpp
+++ b/src/OpenAir.cpp
@@ -699,8 +699,11 @@ bool OpenAir::Write(const std::string& fileName) {
 }
 
 void OpenAir::WriteHeader() {
+	file << "*VERSION: 2.0\n";
+	file << "*WRITTEN_BY: AirspaceConverter\n";
+	file << "*DATE: " << AirspaceConverter::GetCurrentDateString() << "\n";
 	for(const std::string& line: AirspaceConverter::disclaimer) file << "* " << line << "\n";
-	file << "\n* " << AirspaceConverter::GetCreationDateString() << "\n\n";
+	file << "\n* " << AirspaceConverter::GetFullCreationDateTimeString() << "\n\n";
 }
 
 bool OpenAir::WriteCategory(const Airspace& airspace) {

--- a/src/OpenAir.cpp
+++ b/src/OpenAir.cpp
@@ -13,10 +13,10 @@
 #include "OpenAir.hpp"
 #include "AirspaceConverter.hpp"
 #include <iomanip>
+#include <format>
 #include <boost/algorithm/string.hpp>
 #include <boost/tokenizer.hpp>
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/format.hpp>
 #include <boost/locale/encoding.hpp>
 
 const std::unordered_map<std::string, Airspace::Type> OpenAir::openAirAirspaceTable = {
@@ -118,7 +118,7 @@ bool OpenAir::ParseDegrees(const std::string& dddmmss, double& deg, bool isLon) 
 		if ((*token).length() != (isLon ? 3 : 2)) warnDegDigits = true;
 		deg = std::stod(*token);
 		if (deg < 0 || deg >= (isLon ? 180 : 90)) {
-			AirspaceConverter::LogError(boost::str(boost::format("on line %1d: invalid value of degrees for %s.") % linecount %(isLon ? "longitude" : "latitude")));
+			AirspaceConverter::LogError(std::format("on line {}: invalid value of degrees for {}.", linecount, isLon ? "longitude" : "latitude"));
 			return false;
 		}
 
@@ -128,7 +128,7 @@ bool OpenAir::ParseDegrees(const std::string& dddmmss, double& deg, bool isLon) 
 			if (fields == 3 && (*token).length() != 2) warnMinDigits = true;
 			const double min = std::stod(*token);
 			if (min < 0 || min >= 60) {
-				AirspaceConverter::LogError(boost::str(boost::format("on line %1d: invalid value of minutes for %s.") % linecount %(isLon ? "longitude" : "latitude")));
+				AirspaceConverter::LogError(std::format("on line {}: invalid value of minutes for {}.", linecount, isLon ? "longitude" : "latitude"));
 				return false;
 			}
 			deg += min / 60;
@@ -137,14 +137,14 @@ bool OpenAir::ParseDegrees(const std::string& dddmmss, double& deg, bool isLon) 
 			if (++token != tokens.end()) {
 				if ((*token).empty()) return false;
 				if (warnDegDigits)
-					AirspaceConverter::LogWarning(boost::str(boost::format("on line %1d: wrong number of digits for %s degrees.") % linecount %(isLon ? "longitude" : "latitude")));
+					AirspaceConverter::LogWarning(std::format("on line {}: wrong number of digits for {} degrees.", linecount, isLon ? "longitude" : "latitude"));
 				if (warnMinDigits)
-					AirspaceConverter::LogWarning(boost::str(boost::format("on line %1d: wrong number of digits for %s minutes.") % linecount %(isLon ? "longitude" : "latitude")));
+					AirspaceConverter::LogWarning(std::format("on line {}: wrong number of digits for {} minutes.", linecount, isLon ? "longitude" : "latitude"));
 				if ((*token).length() != 2)
-					AirspaceConverter::LogWarning(boost::str(boost::format("on line %1d: wrong number of digits for %s seconds.") % linecount %(isLon ? "longitude" : "latitude")));
+					AirspaceConverter::LogWarning(std::format("on line {}: wrong number of digits for {} seconds.", linecount, isLon ? "longitude" : "latitude"));
 				const double sec = std::stod(*token);
 				if (sec < 0 || sec >= 60) {
-					AirspaceConverter::LogError(boost::str(boost::format("on line %1d: invalid value of seconds for %s.") % linecount %(isLon ? "longitude" : "latitude")));
+					AirspaceConverter::LogError(std::format("on line {}: invalid value of seconds for {}.", linecount, isLon ? "longitude" : "latitude"));
 					return false;
 				}
 				deg += sec / 3600;
@@ -156,7 +156,7 @@ bool OpenAir::ParseDegrees(const std::string& dddmmss, double& deg, bool isLon) 
 
 	// Check if the final value is valid
 	if (deg > (isLon ? 180 : 90)) {
-		AirspaceConverter::LogError(boost::str(boost::format("on line %1d: invalid %s value.") % linecount %(isLon ? "longitude" : "latitude")));
+		AirspaceConverter::LogError(std::format("on line {}: invalid {} value.", linecount, isLon ? "longitude" : "latitude"));
 		return false;
 	}
 
@@ -261,7 +261,7 @@ bool OpenAir::Read(const std::string& fileName) {
 
 		// Verify line ending
 		if (lineEndingConsistent && isCRLF != initialCRLF && !sLine.empty()) {
-			AirspaceConverter::LogWarning(boost::str(boost::format("on line %1d: not consistent line ending style, file started with: %s.") % linecount %(initialCRLF ? "CR LF" : "LF")));
+			AirspaceConverter::LogWarning(std::format("on line {}: not consistent line ending style, file started with: {}.", linecount, initialCRLF ? "CR LF" : "LF"));
 
 			// OpenAir files may contain thousands of lines we don't want to print this warning all the time
 			lineEndingConsistent = false;
@@ -337,7 +337,7 @@ bool OpenAir::Read(const std::string& fileName) {
 				break;
 			case 'Y': // DY
 				//ParseDY(sLine, airspace); // Airway not yet supported
-				AirspaceConverter::LogWarning(boost::str(boost::format("skipping airway segment (not yet supported) on line %1d: %2s") %linecount %sLine));
+				AirspaceConverter::LogWarning(std::format("skipping airway segment (not yet supported) on line {}: {}", linecount, sLine));
 				lineParsedOK = false; 
 				break;
 			default:
@@ -359,7 +359,7 @@ bool OpenAir::Read(const std::string& fileName) {
 			break;
 		}
 		if (!lineParsedOK) {
-			AirspaceConverter::LogError(boost::str(boost::format("unable to parse OpenAir line %1d: %2s") %linecount %sLine));
+			AirspaceConverter::LogError(std::format("unable to parse OpenAir line {}: {}", linecount, sLine));
 			allParsedOK = false;
 		}
 	}
@@ -400,7 +400,7 @@ bool OpenAir::ParseAN(const std::string & line, Airspace& airspace, const bool i
 		airspace.SetName(isUTF8 ? name : boost::locale::conv::between(name, "utf-8", "ISO8859-1"));
 		return true;
 	}
-	AirspaceConverter::LogError(boost::str(boost::format("airspace %1s has already a name.") % airspace.GetName()));
+	AirspaceConverter::LogError(std::format("airspace {} has already a name.", airspace.GetName()));
 	return false;	
 }
 
@@ -464,7 +464,7 @@ bool OpenAir::ParseDP(const std::string& line, Airspace& airspace, const int& li
 			}
 
 			// If the last point equal to the first was alredy detected than there is really a duplicate
-			AirspaceConverter::LogWarning(boost::str(boost::format("skipping unnecessary repeated point on line %1d: %2s") % linenumber % line));	
+			AirspaceConverter::LogWarning(std::format("skipping unnecessary repeated point on line {}: {}", linenumber, line));	
 		}
 		return true;
 	}
@@ -520,7 +520,7 @@ bool OpenAir::ParseDA(const std::string& line, Airspace& airspace, const int& li
 		double radius = std::stod(*token);
 		double angleStart = std::stod(*(++token));
 		double angleEnd = std::stod(*(++token));
-		if (!CheckAngleDeg(angleStart) || !CheckAngleDeg(angleEnd)) AirspaceConverter::LogWarning(boost::str(boost::format("angle not in range 0-360 on line %1d: %2s") % linenumber % line));
+		if (!CheckAngleDeg(angleStart) || !CheckAngleDeg(angleEnd)) AirspaceConverter::LogWarning(std::format("angle not in range 0-360 on line {}: {}", linenumber, line));
 		airspace.AddGeometry(new Sector(varPoint, radius, angleStart, angleEnd, varRotationClockwise));
 	} catch (...) {
 		return false;
@@ -579,15 +579,15 @@ bool OpenAir::InsertAirspace(Airspace& airspace) {
 	bool validAirspace(airspace.GetNumberOfGeometries() > 0);
 
 	if (!validAirspace)
-		AirspaceConverter::LogError(boost::str(boost::format("at line %1d: skip airspace %2s with no geometries.") % lastACline % airspace.GetName()));
+		AirspaceConverter::LogError(std::format("at line {}: skip airspace {} with no geometries.", lastACline, airspace.GetName()));
 
 	if (validAirspace && airspace.GetTopAltitude() <= airspace.GetBaseAltitude()) {
-		AirspaceConverter::LogError(boost::str(boost::format("at line %1d: skip airspace %2s with top and base equal or inverted.") % lastACline % airspace.GetName()));
+		AirspaceConverter::LogError(std::format("at line {}: skip airspace {} with top and base equal or inverted.", lastACline, airspace.GetName()));
 		validAirspace = false;
 	}
 
 	if (validAirspace && airspace.GetTopAltitude().IsGND()) {
-		AirspaceConverter::LogError(boost::str(boost::format("at line %1d: skip airspace %2s with top at GND.") % lastACline % airspace.GetName()));
+		AirspaceConverter::LogError(std::format("at line {}: skip airspace {} with top at GND.", lastACline, airspace.GetName()));
 		validAirspace = false;
 	}
 
@@ -596,7 +596,7 @@ bool OpenAir::InsertAirspace(Airspace& airspace) {
 
 	// Ensure that the points are closed
 	if (validAirspace && !airspace.ClosePoints()) {
-		AirspaceConverter::LogError(boost::str(boost::format("at line %1d: skip airspace %2s with less than 3 points.") % lastACline % airspace.GetName()));
+		AirspaceConverter::LogError(std::format("at line {}: skip airspace {} with less than 3 points.", lastACline, airspace.GetName()));
 		validAirspace = false;
 	}
 
@@ -604,7 +604,7 @@ bool OpenAir::InsertAirspace(Airspace& airspace) {
 	if (validAirspace) {
 
 		// This should be just a warning
-		if (airspace.GetName().empty()) AirspaceConverter::LogWarning(boost::str(boost::format("at line %1d: airspace without name.") % lastACline));
+		if (airspace.GetName().empty()) AirspaceConverter::LogWarning(std::format("at line {}: airspace without name.", lastACline));
 		
 		airspaces.insert(std::pair<int, Airspace>(airspace.GetType(), std::move(airspace)));
 	}
@@ -721,7 +721,7 @@ bool OpenAir::WriteCategory(const Airspace& airspace) {
 		case Airspace::NOGLIDER:	openAirCategory = "GP"; break;
 		case Airspace::GLIDING:		openAirCategory = "GSEC"; break;
 		case Airspace::UNDEFINED:
-			AirspaceConverter::LogWarning(boost::str(boost::format("skipping undefined airspace %1s.") % airspace.GetName()));
+			AirspaceConverter::LogWarning(std::format("skipping undefined airspace {}.", airspace.GetName()));
 			assert(false);
 			return false;
 		default: openAirCategory = airspace.CategoryName(airspace.GetType()); break;

--- a/src/OpenAir.cpp
+++ b/src/OpenAir.cpp
@@ -397,7 +397,7 @@ bool OpenAir::ParseAN(const std::string & line, Airspace& airspace, const bool i
 			name.rfind(airspace.GetCategoryName()) == std::string::npos) { // ... and the name does not alredy contain it ...
 			name.insert (0, airspace.GetCategoryName() + " "); // Then make sure the name contains the type as text
 		}
-		airspace.SetName(isUTF8 ? name : boost::locale::conv::between(name,"utf-8","ISO8859-1"));
+		airspace.SetName(isUTF8 ? name : boost::locale::conv::between(name, "utf-8", "ISO8859-1"));
 		return true;
 	}
 	AirspaceConverter::LogError(boost::str(boost::format("airspace %1s has already a name.") % airspace.GetName()));
@@ -417,7 +417,7 @@ bool OpenAir::ParseAF(const std::string& line, Airspace& airspace, const bool is
 			descr.erase(0,pos);
 			if (descr.at(0) == ' ') descr.erase(0,1); // remove the separating space
 		} else descr.erase();
-		airspace.AddRadioFrequency(freqHz, isUTF8 ? descr : boost::locale::conv::between(descr,"utf-8","ISO8859-1"));
+		airspace.AddRadioFrequency(freqHz, isUTF8 ? descr : boost::locale::conv::between(descr, "utf-8", "ISO8859-1"));
 		return true;
 	} catch(...) {
 		return false;
@@ -647,7 +647,7 @@ bool OpenAir::Write(const std::string& fileName) {
 		if (!WriteCategory(a)) continue;
 
 		// Write the name
-		file << "AN " << boost::locale::conv::between(a.GetName(),"ISO8859-1","utf-8") << "\n";
+		file << "AN " << a.GetName() << "\n";
 		
 		// Write base and ceiling altitudes
 		file << "AL " << a.GetBaseAltitude().ToString() << "\n";
@@ -659,7 +659,7 @@ bool OpenAir::Write(const std::string& fileName) {
 			for (size_t i=0; i<a.GetNumberOfRadioFrequencies(); i++) {
 				const std::pair<int, std::string>& f = a.GetRadioFrequencyAt(i);
 				file << "AF " << AirspaceConverter::FrequencyMHz(f.first);
-				if (!f.second.empty()) file << ' ' << boost::locale::conv::between(f.second,"ISO8859-1","utf-8");
+				if (!f.second.empty()) file << ' ' << f.second;
 				file << "\n";
 			}
 			file.unsetf(std::ios_base::floatfield); //file << std::defaultfloat; not supported by older GCC 4.9.0

--- a/src/OpenAir.cpp
+++ b/src/OpenAir.cpp
@@ -662,7 +662,7 @@ bool OpenAir::Write(const std::string& fileName) {
 				if (!f.second.empty()) file << ' ' << f.second;
 				file << "\n";
 			}
-			file.unsetf(std::ios_base::floatfield); //file << std::defaultfloat; not supported by older GCC 4.9.0
+			file << std::defaultfloat;
 		}
 
 		// Write transponder code

--- a/src/OpenAir.hpp
+++ b/src/OpenAir.hpp
@@ -60,6 +60,8 @@ private:
 	void WriteHeader();
 	bool WriteCategory(const Airspace& airsapce);
 	void WritePoint(const Geometry::LatLon& point, bool isCenterPoint = false, bool addPrefix = true);
+	void WriteLatLonDDMMSS(const int& latD, const int& latM, const int& latS, const char& NorS, const int& lonD, const int& lonM, const int& lonS, const char& EorW);
+	void WriteLatLonDDMMmmm(const int& latD, const double& latM, const char& NorS, const int& lonD, const double& lonM, const char& EorW);
 	void WritePoint(const Point& point);
 	void WriteCircle(const Circle& circle);
 	void WriteSector(const Sector& sector);

--- a/src/OpenAir.hpp
+++ b/src/OpenAir.hpp
@@ -54,8 +54,6 @@ private:
 	bool ParseDA(const std::string& line, Airspace& airspace, const int& linenumber);
 	bool ParseDB(const std::string& line, Airspace& airspace);
 	bool ParseDC(const std::string& line, Airspace& airspace);
-
-	//bool ParseDY(const std::string& line, Airspace& airspace); // Airway not yet supported
 	bool InsertAirspace(Airspace& airspace);
 	void WriteHeader();
 	bool WriteCategory(const Airspace& airsapce);

--- a/src/Polish.cpp
+++ b/src/Polish.cpp
@@ -15,8 +15,8 @@
 #include "Airspace.hpp"
 #include <sstream>
 #include <filesystem>
-#include <boost/algorithm/string/predicate.hpp>
 #include <cassert>
+#include <boost/algorithm/string/predicate.hpp>
 
 /* TODO: customized types
 const int PFMwriter::types[] = {

--- a/src/Polish.cpp
+++ b/src/Polish.cpp
@@ -58,7 +58,7 @@ const std::string Polish::MakeLabel(const Airspace& airspace) {
 
 void Polish::WriteHeader(const std::string& filename) {
 	for(const std::string& line: AirspaceConverter::disclaimer) file << ";" << line << "\n";
-	file << "\n;" << AirspaceConverter::GetCreationDateString() << "\n\n"
+	file << "\n;" << AirspaceConverter::GetFullCreationDateTimeString() << "\n\n"
 		<< "[IMG ID]\n" //section identifier
 		<< "ID=62831853\n" // unique identifier: 2 PI
 		<< "Name=" << std::filesystem::path(filename).stem().string() << "\n" // map name

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,7 @@
 #include "Altitude.hpp"
 
 void printHelp() {
-	std::cout << "Example usage: airspaceconverter -q 1013 -a 35 -i inputFileOpenAir.txt -i openAIP_asp.aip -w waypoints.cup -w openAIP_wpt.aip -m terrainMap.dem -o outputFile.kmz" << std::endl << std::endl;
+	std::cout << "Example usage: airspaceconverter -q 1013 -a 35 -i inputAspFile.openair -i openAIP_asp.aip -w waypoints.cup -w openAIP_wpt.aip -m terrainMap.dem -o outputFile.kmz" << std::endl << std::endl;
 	std::cout << "Possible options:" << std::endl;
 	std::cout << "-q: optional, specify the QNH in hPa used to calculate height of flight levels" << std::endl;
 	std::cout << "-a: optional, specify a default terrain altitude in meters to calculate AGL heights of points not covered by loaded terrain map(s)" << std::endl;
@@ -29,7 +29,7 @@ void printHelp() {
 	std::cout << "    where the limits are comma separated, coordinates expressed in degrees, without spaces, negative for west longitudes and south latitudes" << std::endl;
 	std::cout << "-u: optional, set filter limits on altitude for the output, followed by the 1 or 2 limit values: lowAlt,hiAlt" << std::endl;
 	std::cout << "    altitudes are expressed in feet, at main sea level. If higher limit is omitted it will be considered as unlimited" << std::endl;
-	std::cout << "-o: optional, output file .kmz, .txt (OpenAir), .cup (SeeYou), .csv (LittleNavMap)";
+	std::cout << "-o: optional, output file .kmz (Google Earth), .opnair, .txt (OpenAir), .cup (SeeYou), .csv (LittleNavMap)";
 	if (AirspaceConverter::Is_cGPSmapperAvailable()) std::cout << ", .img (Garmin)";
 	std::cout << " or .mp (Polish). If not specified will be used the name of first input file as KMZ" << std::endl;
 	std::cout << "-p: optional, when writing in OpenAir avoid to use arcs and circles but only points (DP)" << std::endl;


### PR DESCRIPTION
- Output in UTF-8 no need to convert to ISO8859-1
- .openair is also a possible extension for OpenAir files (.txt is the legacy one)
- Header must contain:
- - OpenAIR Version number: *VERSION: 2.0
- - Author (App/Person) of file: *WRITTEN_BY: AirspaceConverter
- - *DATE: 30-08-2025
- Consistency in printing the coordinates as DD:MM:SS or DD:MM.mmm
