### PR TITLE
OpenAir: close the poligons made of only DP points

### DIFF
--- a/src/OpenAir.cpp
+++ b/src/OpenAir.cpp
@@ -673,8 +673,8 @@ bool OpenAir::Write(const std::string& fileName) {
 			for (size_t i = 0; i < numOfGeometries; i++) a.GetGeometryAt(i)->WriteOpenAirGeometry(*this);
 		}
 
-		// Otherwise write every single point (except the last one which is the same)
-		else for (size_t i = 0; i < a.GetNumberOfPoints() - 1; i++) WritePoint(a.GetPointAt(i));
+		// Otherwise write every single point, including last one which must be equal to the first one to close the polygon
+		else for (size_t i = 0; i < a.GetNumberOfPoints(); i++) WritePoint(a.GetPointAt(i));
 
 		// Add an empty line at the end of the airspace
 		file << "\n";

--- a/src/OpenAir.hpp
+++ b/src/OpenAir.hpp
@@ -72,7 +72,6 @@ private:
 	std::multimap<int, Airspace>& airspaces;
 	bool varRotationClockwise;
 	Geometry::LatLon varPoint;
-	//double varWidth;
 	std::ofstream file;
 	int lastACline;
 	bool lastPointWasDDMMSS;


### PR DESCRIPTION
It appear that the when selecting the option to use only DP points the polygons are not being closed repeating the first point at the end. This PR fixes this problem.